### PR TITLE
Fix runtime imports and improve schema push script

### DIFF
--- a/scripts/push-error-logs.js
+++ b/scripts/push-error-logs.js
@@ -1,19 +1,14 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
 
-// Create a file to pipe the input
-fs.writeFileSync('push-input.txt', '1\ny\n');
-
 try {
-  // Use the file as input to the drizzle-kit push command
-  execSync('drizzle-kit push < push-input.txt', { 
+  // Provide the automatic confirmation input directly to the command
+  execSync('drizzle-kit push', {
+    input: '1\ny\n',
     stdio: ['pipe', process.stdout, process.stderr],
     timeout: 30000
   });
   console.log('Successfully pushed error_logs table to database!');
 } catch (error) {
   console.error('Error pushing schema:', error.message);
-} finally {
-  // Clean up
-  fs.unlinkSync('push-input.txt');
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -37,6 +37,9 @@ import projectManagementRoutes from './routes/project-management-routes';
 import { diditConnector } from './services/didit-connector';
 import logger from './utils/logger';
 import { ErrorLogger } from './services/error-logger';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
 
 // Import the DatabaseStorage class if it exists
 let DatabaseStorage: any;

--- a/server/routes/image-processing.ts
+++ b/server/routes/image-processing.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from 'express';
 import multer from 'multer';
 import fs from 'fs';
 import path from 'path';
+import { createCanvas } from 'canvas';
 import { imageProcessingService } from '../services/image-processing-service';
 import { storage as globalStorage } from '../storage';
 

--- a/server/routes/training-integration-routes.ts
+++ b/server/routes/training-integration-routes.ts
@@ -430,7 +430,7 @@ router.post('/test-connection', isAdmin, async (req, res) => {
       }
       
       // Create a temporary Moodle service to test
-      const { createMoodleService } = require('../services/moodle-service');
+      const { createMoodleService } = await import('../services/moodle-service');
       const moodleService = createMoodleService(connectionData.baseUrl, connectionData.authToken);
       
       // Try to get site info
@@ -448,7 +448,7 @@ router.post('/test-connection', isAdmin, async (req, res) => {
       }
       
       // Create a temporary Zoom service to test
-      const { createZoomService } = require('../services/zoom-service');
+      const { createZoomService } = await import('../services/zoom-service');
       const zoomService = createZoomService(connectionData.clientId, connectionData.clientSecret);
       
       // Try to get access token


### PR DESCRIPTION
## Summary
- handle dynamic imports using createRequire in routes
- switch to async dynamic imports in training integration routes
- streamline drizzle push script for error logs

## Testing
- `npm run check` *(fails: Cannot find type definitions, requires network)*