### PR TITLE
Fix comment for PATCH /projects/new

### DIFF
--- a/server/routes/project-management-routes.ts
+++ b/server/routes/project-management-routes.ts
@@ -106,7 +106,8 @@ projectManagementRouter.get('/projects', ensureAuthenticated, async (req: Reques
   }
 });
 
-// Special route to handle the "new" endpoint - redirects to the POST /projects endpoint
+// PATCH /projects/new creates a project for clients that send PATCH
+// rather than performing an HTTP redirect.
 projectManagementRouter.patch('/projects/new', ensureAuthenticated, async (req: Request, res: Response) => {
   try {
     console.log('Received PATCH to /projects/new, redirecting to POST /projects');


### PR DESCRIPTION
## Summary
- clarify comment for the `/projects/new` PATCH route that it directly creates a project instead of doing an HTTP redirect

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*