### PR TITLE
Ensure setup installs dependencies

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
-npm install            # or other commands to install dependencies
+# Fail on any error
+set -e
+
+# Install all project dependencies so subsequent npm scripts run correctly
+npm install


### PR DESCRIPTION
## Summary
- ensure `npm install` runs and fails fast in setup script

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: vite not found)*
