### PR TITLE
Require SESSION_SECRET in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# AIWebFramework
+
+This project is a Node.js/Express server with a React-based frontend. It requires Node.js 18+.
+
+## Running Locally
+
+```bash
+npm install
+npm run dev
+```
+
+## Type Checking
+
+To run the TypeScript checks used by `npm run check`, install dependencies first:
+
+```bash
+npm install
+npm run check
+```
+
+## Deployment Notes
+
+When deploying to production (`NODE_ENV=production`), you **must** define the `SESSION_SECRET` environment variable. The server will refuse to start without it and session cookies will be marked as secure.

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,6 +12,11 @@ import { requestLogger, errorMonitor } from "./middleware/error-monitoring";
 import logger from "./utils/logger";
 import { attachUser } from "./middleware/auth";
 
+const isProduction = process.env.NODE_ENV === 'production';
+if (isProduction && !process.env.SESSION_SECRET) {
+  throw new Error('SESSION_SECRET environment variable is required in production');
+}
+
 /**
  * Initialize default data in the database
  * This ensures we have essential data like ID card templates
@@ -87,8 +92,8 @@ app.use(session({
   resave: true, // Changed to true to ensure session is saved on each request
   saveUninitialized: false,
   name: 'observer.sid', // Custom name to avoid conflicts
-  cookie: { 
-    secure: false, // Set to false to ensure cookies work in development environment
+  cookie: {
+    secure: isProduction,
     maxAge: 1000 * 60 * 60 * 24 * 7, // 1 week
     httpOnly: true,
     sameSite: 'lax',


### PR DESCRIPTION
## Summary
- ensure `SESSION_SECRET` is provided when `NODE_ENV` is production
- make session cookies secure in production
- document the new environment variable requirement
- note how to run the type checker

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
