### PR TITLE
Fix IdCardTemplate type import

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -36,6 +36,7 @@ import {
   type InsertPhotoApproval,
   type Role,
   type InsertRole,
+  type IdCardTemplate,
 } from "@shared/schema";
 
 // Interface for storage operations


### PR DESCRIPTION
## Summary
- fix missing `IdCardTemplate` type in server storage interface

## Testing
- `npx tsc` *(fails: Property 'labels' does not exist on type 'ObjectDetectionOutput', etc.)*