### PR TITLE
Address autocomplete fallback when HERE API fails

### DIFF
--- a/client/src/components/address/address-autocomplete.tsx
+++ b/client/src/components/address/address-autocomplete.tsx
@@ -404,11 +404,17 @@ export default function AddressAutocomplete({
               isLoaded ? "border-gray-300 hover:border-gray-400" : "border-gray-200 bg-gray-50", 
               className
             )}
-            placeholder={isLoaded ? placeholder : "Loading map service..."}
+            placeholder={
+              loadError
+                ? "Map service unavailable. Enter address manually..."
+                : isLoaded
+                  ? placeholder
+                  : "Loading map service..."
+            }
             value={inputValue}
             onChange={handleInputChange}
             onFocus={handleInputFocus}
-            disabled={disabled || !isLoaded || !!loadError}
+            disabled={disabled}
           />
           {isSearching ? (
             <div className="absolute right-3 top-1/2 transform -translate-y-1/2">


### PR DESCRIPTION
## Summary
- if HERE Maps fails to load, allow manual address input instead of disabling the field

## Testing
- `npm run check` *(fails: Property 'mask' does not exist on type 'ImageSegmentationOutput', etc.)*