### PR TITLE
Add production check to mock verification

### DIFF
--- a/server/routes/didit-verification.ts
+++ b/server/routes/didit-verification.ts
@@ -68,10 +68,16 @@ router.get('/initiate', ensureAuthenticated, async (req: Request, res: Response)
 // Mock verification route to prevent crashes during testing
 router.get('/mockverify', async (req: Request, res: Response) => {
   try {
+    if (process.env.NODE_ENV === 'production') {
+      return res.status(403).render('error', {
+        message: 'Mock verification is disabled in production'
+      });
+    }
+
     const email = req.query.email as string;
     if (!email) {
-      return res.status(400).render('error', { 
-        message: 'Email parameter is required' 
+      return res.status(400).render('error', {
+        message: 'Email parameter is required'
       });
     }
 
@@ -82,8 +88,8 @@ router.get('/mockverify', async (req: Request, res: Response) => {
     });
   } catch (error) {
     console.error('Error with mock verification:', error);
-    return res.status(500).render('error', { 
-      message: 'Failed during mock verification process' 
+    return res.status(500).render('error', {
+      message: 'Failed during mock verification process'
     });
   }
 });


### PR DESCRIPTION
## Summary
- prevent `/mockverify` route from running in production

## Testing
- `npm run check` *(fails: Property errors in TypeScript files)*

------
https://chatgpt.com/codex/tasks/task_e_6830fe21c680832da32f340c5f129f13