### PR TITLE
Add basic news management pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,7 @@ import Training from "@/pages/training";
 import IntegratedTraining from "@/pages/integrated-training";
 import Faq from "@/pages/faq";
 import Chat from "@/pages/chat";
+import NewsPage from "@/pages/news";
 import FormTemplates from "@/pages/form-templates";
 import Admin from "@/pages/admin";
 import AdminDashboard from "@/pages/admin-dashboard";
@@ -46,6 +47,7 @@ import ProjectEdit from "@/pages/project-management/edit";
 import ProjectNew from "@/pages/project-management/new";
 import GamificationPage from "@/pages/gamification";
 import SecurityDashboard from "@/pages/security-dashboard";
+import AdminNewsPage from "@/pages/admin/news";
 import { AuthProvider } from "@/hooks/useAuth";
 import { ProtectedRoute, RoleProtectedRoute } from "@/lib/protected-route";
 import ErrorBoundary from "@/components/error/error-boundary";
@@ -83,6 +85,7 @@ function Router() {
       <ProtectedRoute path="/assignments" component={AssignmentsPage} />
       <ProtectedRoute path="/training" component={IntegratedTraining} />
       <ProtectedRoute path="/chat" component={Chat} />
+      <ProtectedRoute path="/news" component={NewsPage} />
       {/* Redirect communications route to /chat to avoid duplicate routes */}
       <Route path="/communications" component={() => <Redirect to="/chat" />} />
       <ProtectedRoute path="/gamification" component={GamificationPage} />
@@ -111,6 +114,7 @@ function Router() {
       <RoleProtectedRoute path="/admin/user-imports" component={UserImportsPage} allowedRoles={["admin", "director"]} />
       <RoleProtectedRoute path="/admin/analytics" component={Analytics} allowedRoles={["admin", "director"]} />
       <RoleProtectedRoute path="/admin/settings" component={AdminSettings} allowedRoles={["admin", "director"]} />
+      <RoleProtectedRoute path="/admin/news" component={AdminNewsPage} allowedRoles={["admin", "director"]} />
       <RoleProtectedRoute path="/admin/permissions" component={PermissionManagement} allowedRoles={["admin", "director"]} />
       <RoleProtectedRoute path="/admin/error-logs" component={ErrorLogsPage} allowedRoles={["admin", "director"]} />
       <RoleProtectedRoute path="/admin/security" component={SecurityDashboard} allowedRoles={["admin", "director"]} />

--- a/client/src/components/news/news-list.tsx
+++ b/client/src/components/news/news-list.tsx
@@ -1,0 +1,107 @@
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Clock } from "lucide-react";
+import { type News } from '@shared/schema';
+
+function formatDate(dateInput: Date | string | undefined) {
+  if (!dateInput) return "Unknown date";
+  const date = typeof dateInput === 'string' ? new Date(dateInput) : dateInput;
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export default function NewsList() {
+  const { data: news, isLoading, error } = useQuery<News[]>({
+    queryKey: ['/api/news'],
+  });
+
+  const getCategoryBadge = (category: string) => {
+    const categoryLower = category.toLowerCase();
+    switch (categoryLower) {
+      case 'announcement':
+        return <Badge className="bg-blue-100 text-blue-800 hover:bg-blue-100">{category}</Badge>;
+      case 'training':
+        return <Badge className="bg-green-100 text-green-800 hover:bg-green-100">{category}</Badge>;
+      case 'alert':
+        return <Badge className="bg-red-100 text-red-800 hover:bg-red-100">{category}</Badge>;
+      case 'update':
+        return <Badge className="bg-purple-100 text-purple-800 hover:bg-purple-100">{category}</Badge>;
+      default:
+        return <Badge variant="outline">{category}</Badge>;
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg font-medium">News</CardTitle>
+        </CardHeader>
+        <CardContent className="divide-y divide-gray-200">
+          {[1,2,3].map(i => (
+            <div key={i} className="p-6 animate-pulse">
+              <Skeleton className="h-5 w-20 mb-2" />
+              <Skeleton className="h-5 w-48 mb-2" />
+              <Skeleton className="h-4 w-full mb-3" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    const axiosError = error as any;
+    const errorMsg = axiosError?.response?.data?.error || axiosError?.data?.error || axiosError?.message || 'Please try again later.';
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg font-medium">News</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-red-500">Error loading news: {errorMsg}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!news || news.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg font-medium">News</CardTitle>
+        </CardHeader>
+        <CardContent className="py-6 text-center">
+          <p className="text-gray-500">No news items available.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg font-medium">News</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0 divide-y divide-gray-200">
+        {news.map(item => (
+          <div key={item.id} className="p-6">
+            {item.category && getCategoryBadge(item.category)}
+            <h4 className="font-medium text-gray-900 mt-2">{item.title || 'Untitled'}</h4>
+            <p className="text-sm text-gray-500 mt-1">{item.content || 'No content available'}</p>
+            <div className="flex items-center mt-3 text-xs text-gray-500">
+              <Clock className="h-4 w-4 mr-1" />
+              <span>{formatDate(item.createdAt)}</span>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/admin/news.tsx
+++ b/client/src/pages/admin/news.tsx
@@ -1,0 +1,144 @@
+import React, { useState, FormEvent } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import AdminLayout from '@/components/layout/admin-layout';
+import { apiRequest } from '@/lib/queryClient';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { type News } from '@shared/schema';
+
+export default function AdminNewsPage() {
+  const queryClient = useQueryClient();
+  const { data: news = [], isLoading } = useQuery<News[]>({ queryKey: ['/api/news'] });
+
+  const addMutation = useMutation({
+    mutationFn: async (data: { title: string; content: string; category: string; isPublished: boolean }) => {
+      const res = await apiRequest('POST', '/api/news', data);
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/news'] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) => {
+      await apiRequest('DELETE', `/api/news/${id}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/api/news'] });
+    },
+  });
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [formState, setFormState] = useState({ title: '', content: '', category: '', isPublished: true });
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    addMutation.mutate(formState);
+    setDialogOpen(false);
+    setFormState({ title: '', content: '', category: '', isPublished: true });
+  };
+
+  return (
+    <AdminLayout title="News Management">
+      <div className="p-6 space-y-6">
+        <div className="flex justify-between items-center">
+          <h1 className="text-3xl font-bold">News Management</h1>
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger asChild>
+              <Button>Add News</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>New News Entry</DialogTitle>
+              </DialogHeader>
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <Input
+                  placeholder="Title"
+                  value={formState.title}
+                  onChange={(e) => setFormState({ ...formState, title: e.target.value })}
+                />
+                <Input
+                  placeholder="Category"
+                  value={formState.category}
+                  onChange={(e) => setFormState({ ...formState, category: e.target.value })}
+                />
+                <Textarea
+                  placeholder="Content"
+                  value={formState.content}
+                  onChange={(e) => setFormState({ ...formState, content: e.target.value })}
+                />
+                <label className="flex items-center gap-2">
+                  <Checkbox
+                    checked={formState.isPublished}
+                    onCheckedChange={(v) => setFormState({ ...formState, isPublished: !!v })}
+                  />
+                  Published
+                </label>
+                <DialogFooter>
+                  <Button type="submit">Save</Button>
+                </DialogFooter>
+              </form>
+            </DialogContent>
+          </Dialog>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>All News</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <p>Loading...</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Title</TableHead>
+                    <TableHead>Category</TableHead>
+                    <TableHead>Created</TableHead>
+                    <TableHead>Published</TableHead>
+                    <TableHead>Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {news.map((n) => (
+                    <TableRow key={n.id}>
+                      <TableCell>{n.title}</TableCell>
+                      <TableCell>{n.category}</TableCell>
+                      <TableCell>{new Date(n.createdAt as any).toLocaleDateString()}</TableCell>
+                      <TableCell>{n.isPublished ? 'Yes' : 'No'}</TableCell>
+                      <TableCell>
+                        <Button size="sm" variant="destructive" onClick={() => deleteMutation.mutate(n.id)}>
+                          Delete
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/client/src/pages/news.tsx
+++ b/client/src/pages/news.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { useLocation } from "wouter";
+import { useAuth } from "@/hooks/useAuth";
+import NewsList from "@/components/news/news-list";
+import { AuthGuard } from "@/components/auth/auth-guard";
+
+export default function NewsPage() {
+  const { user, isLoading } = useAuth();
+  const [, navigate] = useLocation();
+
+  useEffect(() => {
+    if (!user && !isLoading) {
+      navigate("/login");
+    }
+  }, [user, isLoading, navigate]);
+
+  return (
+    <AuthGuard>
+      <div className="container mx-auto py-6">
+        <NewsList />
+      </div>
+    </AuthGuard>
+  );
+}


### PR DESCRIPTION
## Summary
- add `NewsList` component
- create `/news` page displaying news for users
- create admin news management page
- add routes for news pages in app router

## Testing
- `npm run check` *(fails: Property 'labels' does not exist on type 'ObjectDetectionOutput' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683e76100e44832db239cf3b4bd1e5ca