### PR TITLE
Add README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# AIWebFramework
+
+This repository contains a web framework built with Node.js and TypeScript.
+
+## Development Setup
+
+Before running the project's type checks, make sure all dependencies are installed. The `.codex/setup.sh` script automatically runs `npm install` to install the required packages when the Codex environment is created.
+
+To run checks locally, install dependencies and then execute the check script:
+
+```bash
+npm install && npm run check
+```
+
+Running `npm run check` without installing dependencies first may fail if packages are missing.
+


### PR DESCRIPTION
## Summary
- add a README with basic project information
- explain that dependencies must be installed before running `npm run check`
- mention `.codex/setup.sh` which runs `npm install`
- show example commands for local development

## Testing
- `npm run check` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_683e52d3cff8832dbc98bc0ed97f0b13