### PR TITLE
Add offline voice memo support

### DIFF
--- a/client/src/components/offline/voice-memos.tsx
+++ b/client/src/components/offline/voice-memos.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import RecordRTC, { RecordRTCPromisesHandler } from 'recordrtc';
+import { Button } from '@/components/ui/button';
+
+interface LocalMemo {
+  id: string;
+  blob: Blob;
+  synced: boolean;
+}
+
+export function VoiceMemos() {
+  const [recorder, setRecorder] = useState<RecordRTCPromisesHandler | null>(null);
+  const [recording, setRecording] = useState(false);
+  const [memos, setMemos] = useState<LocalMemo[]>([]);
+
+  // Load unsynced memos from localStorage
+  useEffect(() => {
+    const stored = localStorage.getItem('voiceMemos');
+    if (stored) {
+      const arr: { id: string; data: string; synced: boolean }[] = JSON.parse(stored);
+      arr.forEach(item => {
+        fetch(item.data).then(r => r.blob()).then(b => {
+          setMemos(m => [...m, { id: item.id, blob: b, synced: item.synced }]);
+        });
+      });
+    }
+  }, []);
+
+  const saveMemos = (items: LocalMemo[]) => {
+    Promise.all(items.map(async m => ({
+      id: m.id,
+      data: await blobToDataURL(m.blob),
+      synced: m.synced
+    }))).then(arr => {
+      localStorage.setItem('voiceMemos', JSON.stringify(arr));
+    });
+  };
+
+  const blobToDataURL = (blob: Blob) => new Promise<string>(resolve => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.readAsDataURL(blob);
+  });
+
+  const startRecording = async () => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const rec = new RecordRTCPromisesHandler(stream, { type: 'audio' });
+    await rec.startRecording();
+    setRecorder(rec);
+    setRecording(true);
+  };
+
+  const stopRecording = async () => {
+    if (!recorder) return;
+    await recorder.stopRecording();
+    const blob = await recorder.getBlob();
+    const id = Date.now().toString();
+    const memo: LocalMemo = { id, blob, synced: false };
+    const next = [...memos, memo];
+    setMemos(next);
+    saveMemos(next);
+    setRecording(false);
+  };
+
+  const syncMemos = async () => {
+    const updated: LocalMemo[] = [];
+    for (const memo of memos) {
+      if (memo.synced) { updated.push(memo); continue; }
+      const formData = new FormData();
+      formData.append('file', memo.blob, `memo-${memo.id}.webm`);
+      try {
+        const res = await fetch('/api/voice-memos', { method: 'POST', body: formData });
+        if (res.ok) {
+          updated.push({ ...memo, synced: true });
+        } else {
+          updated.push(memo);
+        }
+      } catch {
+        updated.push(memo);
+      }
+    }
+    setMemos(updated);
+    saveMemos(updated);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Button onClick={recording ? stopRecording : startRecording}>
+        {recording ? 'Stop Recording' : 'Record Voice Memo'}
+      </Button>
+      <Button onClick={syncMemos} disabled={!navigator.onLine || memos.every(m => m.synced)}>
+        Sync Pending ({memos.filter(m => !m.synced).length})
+      </Button>
+      <ul className="text-sm">
+        {memos.map(m => (
+          <li key={m.id}>{m.synced ? 'Synced' : 'Pending'} memo {m.id}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/pages/advanced-features.tsx
+++ b/client/src/pages/advanced-features.tsx
@@ -6,11 +6,12 @@ import { Button } from '@/components/ui/button';
 import { PageWrapper } from '@/components/ui/page-wrapper';
 import { ModernCard } from '@/components/ui/modern-card';
 import { Breadcrumb } from '@/components/ui/breadcrumb';
-import { Sparkles, Brain, Users, Smartphone, BarChart, Zap, Globe, Shield } from 'lucide-react';
+import { Sparkles, Brain, Users, Smartphone, BarChart, Zap, Globe, Shield, Mic } from 'lucide-react';
 import { AIAssistant } from '@/components/advanced/ai-assistant';
 import { RealTimeCollaboration } from '@/components/advanced/real-time-collaboration';
 import { SmartAnalytics } from '@/components/advanced/smart-analytics';
 import { ProgressiveWebApp } from '@/components/advanced/progressive-web-app';
+import { VoiceMemos } from '@/components/offline/voice-memos';
 
 export default function AdvancedFeatures() {
   const [activeTab, setActiveTab] = useState('ai-assistant');
@@ -51,6 +52,15 @@ export default function AdvancedFeatures() {
       badge: 'Offline Ready',
       color: 'text-orange-600',
       component: <ProgressiveWebApp />
+    },
+    {
+      id: 'voice-memos',
+      title: 'Offline Voice Memos',
+      description: 'Record audio reports that sync when connection returns',
+      icon: <Mic className="h-5 w-5" />,
+      badge: 'Offline',
+      color: 'text-teal-600',
+      component: <VoiceMemos />
     }
   ];
 

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -10,6 +10,7 @@ import {
   userProfiles,
   reports,
   reportAttachments,
+  voiceMemos,
   formTemplates,
   events,
   eventParticipation,
@@ -38,6 +39,8 @@ import {
   type InsertReport,
   type ReportAttachment,
   type InsertReportAttachment,
+  type VoiceMemo,
+  type InsertVoiceMemo,
   type FormTemplate,
   type InsertFormTemplate,
   type RegistrationForm,
@@ -1585,6 +1588,40 @@ export class DatabaseStorage implements IStorage {
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       logger.error(`Error getting achievement progress for user ${userId}: ${err.message}`, err);
+      throw err;
+    }
+  }
+
+  // Voice memo operations
+  async createVoiceMemo(memo: InsertVoiceMemo): Promise<VoiceMemo> {
+    try {
+      const [created] = await db.insert(voiceMemos).values(memo).returning();
+      logger.info(`Created voice memo ${created.id} for user ${created.userId}`);
+      return created;
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logger.error(`Error creating voice memo: ${err.message}`, err);
+      throw err;
+    }
+  }
+
+  async getVoiceMemo(id: number): Promise<VoiceMemo | undefined> {
+    try {
+      const [memo] = await db.select().from(voiceMemos).where(eq(voiceMemos.id, id));
+      return memo;
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logger.error(`Error fetching voice memo ${id}: ${err.message}`, err);
+      throw err;
+    }
+  }
+
+  async getVoiceMemosByUserId(userId: number): Promise<VoiceMemo[]> {
+    try {
+      return await db.select().from(voiceMemos).where(eq(voiceMemos.userId, userId)).orderBy(desc(voiceMemos.uploadedAt));
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logger.error(`Error fetching voice memos for user ${userId}: ${err.message}`, err);
       throw err;
     }
   }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -30,6 +30,7 @@ import communicationRoutes, { setCommunicationService } from './routes/communica
 import pollingStationsRoutes from './routes/polling-stations';
 import reportAttachmentsRoutes from './routes/report-attachments';
 import quickReportsRoutes from './routes/quick-reports';
+import voiceMemoRoutes from './routes/voice-memos';
 import newsEnhancedPredictionsRoutes from './routes/news-enhanced-predictions';
 // New comprehensive CRUD routes
 import newsRoutes from './routes/news-routes';
@@ -2336,6 +2337,9 @@ app.post('/api/users/profile', ensureAuthenticated, async (req, res) => {
 
   // AI-powered image processing routes
   app.use('/api/images', imageProcessingRoutes);
+
+  // Offline voice memo uploads
+  app.use('/api/voice-memos', voiceMemoRoutes);
 
   // Add Didit.me verification routes
   app.use('/api/verification', diditVerificationRoutes);

--- a/server/routes/voice-memos.ts
+++ b/server/routes/voice-memos.ts
@@ -1,0 +1,87 @@
+import { Router } from 'express';
+import { ensureAuthenticated } from '../middleware/auth';
+import multer from 'multer';
+import path from 'path';
+import fs from 'fs';
+import { storage } from '../storage';
+
+const upload = multer({
+  storage: multer.diskStorage({
+    destination: (_req, _file, cb) => {
+      const dir = path.join(process.cwd(), 'uploads', 'voice-memos');
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      cb(null, dir);
+    },
+    filename: (_req, file, cb) => {
+      const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+      const ext = path.extname(file.originalname);
+      cb(null, `voice-${unique}${ext}`);
+    }
+  }),
+  limits: {
+    fileSize: 50 * 1024 * 1024,
+  }
+});
+
+const router = Router();
+
+router.post('/', ensureAuthenticated, upload.single('file'), async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ message: 'No file uploaded' });
+    }
+
+    const memo = await storage.createVoiceMemo({
+      userId: req.user!.id,
+      fileType: req.file.mimetype,
+      fileName: req.file.originalname,
+      filePath: req.file.path,
+      fileSize: req.file.size,
+      duration: parseFloat((req.body.duration as string) || '0'),
+      transcript: req.body.transcript || null,
+    });
+
+    res.status(201).json(memo);
+  } catch (error) {
+    console.error('Error uploading voice memo:', error);
+    res.status(500).json({ message: 'Failed to upload voice memo' });
+  }
+});
+
+router.get('/', ensureAuthenticated, async (req, res) => {
+  try {
+    const memos = await storage.getVoiceMemosByUserId(req.user!.id);
+    res.json(memos);
+  } catch (error) {
+    console.error('Error fetching voice memos:', error);
+    res.status(500).json({ message: 'Failed to fetch memos' });
+  }
+});
+
+router.get('/:memoId', ensureAuthenticated, async (req, res) => {
+  try {
+    const memoId = parseInt(req.params.memoId);
+    if (isNaN(memoId)) return res.status(400).json({ message: 'Invalid memo ID' });
+
+    const memo = await storage.getVoiceMemo(memoId);
+    if (!memo) return res.status(404).json({ message: 'Voice memo not found' });
+    if (memo.userId !== req.user!.id && req.user!.role !== 'admin') {
+      return res.status(403).json({ message: 'You do not have permission to access this memo' });
+    }
+    if (!fs.existsSync(memo.filePath)) {
+      return res.status(404).json({ message: 'File not found on server' });
+    }
+
+    res.setHeader('Content-Disposition', `attachment; filename="${memo.fileName}"`);
+    res.setHeader('Content-Type', memo.fileType);
+    const stream = fs.createReadStream(memo.filePath);
+    stream.pipe(res);
+  } catch (error) {
+    console.error('Error downloading voice memo:', error);
+    res.status(500).json({ message: 'Failed to download memo' });
+  }
+});
+
+export default router;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -16,6 +16,8 @@ import {
   type InsertReport,
   type ReportAttachment,
   type InsertReportAttachment,
+  type VoiceMemo,
+  type InsertVoiceMemo,
   type FormTemplate,
   type InsertFormTemplate,
   type Event,
@@ -156,6 +158,11 @@ export interface IStorage {
   getAchievementProgress(userId: number, achievementId: number): Promise<AchievementProgress | undefined>;
   updateAchievementProgress(userId: number, achievementId: number, progress: number, progressData?: any): Promise<AchievementProgress>;
   getUserAchievementProgress(userId: number): Promise<AchievementProgress[]>;
+
+  // Voice memo operations
+  createVoiceMemo(memo: InsertVoiceMemo): Promise<VoiceMemo>;
+  getVoiceMemo(id: number): Promise<VoiceMemo | undefined>;
+  getVoiceMemosByUserId(userId: number): Promise<VoiceMemo[]>;
 }
 
 // Import database storage

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -228,6 +228,21 @@ export const reportAttachments = pgTable("report_attachments", {
   encryptionIv: text("encryption_iv"), // Initialization vector for encryption
 });
 
+// Voice memos recorded by observers
+export const voiceMemos = pgTable("voice_memos", {
+  id: serial("id").primaryKey(),
+  userId: integer("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  fileType: text("file_type").notNull(),
+  fileName: text("file_name").notNull(),
+  filePath: text("file_path").notNull(),
+  fileSize: integer("file_size").notNull(),
+  duration: real("duration"),
+  transcript: text("transcript"),
+  recordedAt: timestamp("recorded_at").defaultNow(),
+  uploadedAt: timestamp("uploaded_at").defaultNow(),
+  encryptionIv: text("encryption_iv"),
+});
+
 // Events and training
 export const events = pgTable("events", {
   id: serial("id").primaryKey(),
@@ -670,6 +685,14 @@ export const insertReportAttachmentSchema = createInsertSchema(reportAttachments
     ocrText: true,
   });
 
+export const insertVoiceMemoSchema = createInsertSchema(voiceMemos)
+  .omit({
+    id: true,
+    uploadedAt: true,
+    recordedAt: true,
+    transcript: true,
+  });
+
 export const insertEventSchema = createInsertSchema(events)
   .omit({
     id: true,
@@ -797,6 +820,9 @@ export type InsertReport = typeof insertReportSchema._type;
 
 export type ReportAttachment = typeof reportAttachments.$inferSelect;
 export type InsertReportAttachment = typeof insertReportAttachmentSchema._type;
+
+export type VoiceMemo = typeof voiceMemos.$inferSelect;
+export type InsertVoiceMemo = typeof insertVoiceMemoSchema._type;
 
 export type Event = typeof events.$inferSelect;
 export type InsertEvent = typeof insertEventSchema._type;


### PR DESCRIPTION
## Summary
- add `voiceMemos` table and insert/type helpers
- implement voice memo CRUD in database storage
- expose new voice memo routes under `/api/voice-memos`
- new `VoiceMemos` React component for recording offline audio
- showcase feature on Advanced Features page

## Testing
- `npm run check` *(fails: Property 'labels' does not exist on type 'ObjectDetectionOutput', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683e7f354cb4832d9ad223dd5c2f9173