### PR TITLE
Fix types in address autocomplete and admin dashboard

### DIFF
--- a/client/src/components/address/address-autocomplete.tsx
+++ b/client/src/components/address/address-autocomplete.tsx
@@ -76,6 +76,7 @@ type AddressSuggestion = {
     city: string;
     district: string;
     street: string;
+    houseNumber?: string;
     postalCode: string;
   };
   position: {

--- a/client/src/components/admin/admin-dashboard.tsx
+++ b/client/src/components/admin/admin-dashboard.tsx
@@ -65,9 +65,16 @@ export default function AdminDashboard() {
   const [activeTab, setActiveTab] = useState("overview");
   
   // Fetch system statistics
-  const { data: systemStats, isLoading, error } = useQuery({
+  const { data: systemStats, isLoading, error } = useQuery<SystemStats>({
     queryKey: ['/api/admin/system-stats'],
     enabled: !!user && user.role === 'admin',
+    queryFn: async () => {
+      const res = await fetch('/api/admin/system-stats');
+      if (!res.ok) {
+        throw new Error('Failed to fetch system statistics');
+      }
+      return res.json() as Promise<SystemStats>;
+    },
   });
   
   if (isLoading) {


### PR DESCRIPTION
## Summary
- resolve type error in address autocomplete by adding `houseNumber` field
- add query function for system stats in admin dashboard

## Testing
- `npm run check` *(fails: TypeScript errors)*


------
https://chatgpt.com/codex/tasks/task_e_684083811f10832d92ea16c080fe529c