### PR TITLE
Fix update depth in toast hook

### DIFF
--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -126,7 +126,7 @@ export const reducer = (state: State, action: Action): State => {
   }
 }
 
-const listeners: Array<(state: State) => void> = []
+const listeners = new Set<(state: State) => void>()
 
 let memoryState: State = { toasts: [] }
 
@@ -172,14 +172,12 @@ function useToast() {
   const [state, setState] = React.useState<State>(memoryState)
 
   React.useEffect(() => {
-    listeners.push(setState)
+    listeners.add(setState)
     return () => {
-      const index = listeners.indexOf(setState)
-      if (index > -1) {
-        listeners.splice(index, 1)
-      }
+      listeners.delete(setState)
     }
-  }, [state])
+    // register once on mount
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- manage toast listeners with a `Set` to avoid duplicate registrations
- run listener effect only once on mount

## Testing
- `npm run check` *(fails: various server-side TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840da5e2b38832d8d360565dfd0d1d5