### PR TITLE
Modernize theme with new palette

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -102,21 +102,21 @@
 
 :root {
   /* Ultra-modern UI color scheme with sophisticated gradients */
-  --background: 0 0% 100%;
-  --foreground: 222 84% 4.9%;
+  --background: 210 20% 98%;
+  --foreground: 222 47% 11%;
   --muted: 210 40% 98%;
   --muted-foreground: 215.4 16.3% 46.9%;
   --popover: 0 0% 100%;
   --popover-foreground: 222 84% 4.9%;
   --card: 0 0% 100%;
   --card-foreground: 222 84% 4.9%;
-  --border: 214.3 31.8% 91.4%;
-  --input: 214.3 31.8% 91.4%;
-  --primary: 262.1 83.3% 57.8%;
+  --border: 215 28% 87%;
+  --input: 215 28% 87%;
+  --primary: 265 83% 62%;
   --primary-foreground: 210 40% 98%;
-  --secondary: 220 14.3% 95.9%;
+  --secondary: 193 95% 45%;
   --secondary-foreground: 220.9 39.3% 11%;
-  --accent: 220 14.3% 95.9%;
+  --accent: 28 94% 55%;
   --accent-foreground: 220.9 39.3% 11%;
   --destructive: 0 84.2% 60.2%;
   --destructive-foreground: 210 40% 98%;
@@ -140,7 +140,7 @@
 
 .dark {
   /* Ultra-modern dark theme with sophisticated depth and contrast */
-  --background: 222.2 84% 4.9%;
+  --background: 222 47% 6%;
   --foreground: 210 40% 98%;
   --muted: 217.2 32.6% 17.5%;
   --muted-foreground: 215 20.2% 65.1%;
@@ -148,13 +148,13 @@
   --popover-foreground: 210 40% 98%;
   --card: 222.2 84% 4.9%;
   --card-foreground: 210 40% 98%;
-  --border: 217.2 32.6% 17.5%;
-  --input: 217.2 32.6% 17.5%;
-  --primary: 263.4 70% 50.4%;
+  --border: 217 19% 24%;
+  --input: 217 19% 24%;
+  --primary: 268 95% 70%;
   --primary-foreground: 210 40% 98%;
-  --secondary: 217.2 32.6% 17.5%;
+  --secondary: 189 85% 60%;
   --secondary-foreground: 210 40% 98%;
-  --accent: 217.2 32.6% 17.5%;
+  --accent: 28 95% 64%;
   --accent-foreground: 210 40% 98%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 210 40% 98%;

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -1739,7 +1739,6 @@ export class DatabaseStorage implements IStorage {
         profile = await this.createUserGameProfile({ userId });
       }
 
-      ```python
       const newTotalPoints = profile.totalPoints + points;
       const newCurrentLevelPoints = profile.currentLevelPoints + points;
 

--- a/server/routes/users-routes.ts
+++ b/server/routes/users-routes.ts
@@ -350,7 +350,7 @@ router.get('/:id/assignments', ensureAuthenticated, hasPermission('users:view-as
     }
     
     // Build where conditions
-    const conditions = [eq(assignments.userId, userId.toString())];
+    const conditions = [eq(assignments.userId, userId)];
     
     if (status) {
       conditions.push(eq(assignments.status, status));
@@ -396,7 +396,7 @@ router.get('/:id/reports', ensureAuthenticated, hasPermission('users:view-report
     }
     
     // Build where conditions
-    const conditions = [eq(reports.userId, userId.toString())];
+    const conditions = [eq(reports.userId, userId)];
     
     if (status) {
       conditions.push(eq(reports.status, status));

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -37,7 +37,7 @@ export default {
       },
       colors: {
         background: {
-          DEFAULT: '#f8fafc',
+          DEFAULT: '#f3f4f6',
         },
         foreground: "hsl(var(--foreground))",
         card: {
@@ -49,11 +49,11 @@ export default {
           foreground: "hsl(var(--popover-foreground))",
         },
         primary: {
-          DEFAULT: '#4f46e5',
+          DEFAULT: '#7c3aed',
           foreground: "hsl(var(--primary-foreground))",
         },
         secondary: {
-          DEFAULT: '#3b82f6',
+          DEFAULT: '#06b6d4',
           foreground: "hsl(var(--secondary-foreground))",
         },
         muted: {
@@ -61,7 +61,7 @@ export default {
           foreground: "hsl(var(--muted-foreground))",
         },
         accent: {
-          DEFAULT: '#34d399',
+          DEFAULT: '#f97316',
           foreground: "hsl(var(--accent-foreground))",
         },
         destructive: {
@@ -69,7 +69,7 @@ export default {
           foreground: "hsl(var(--destructive-foreground))",
         },
         border: {
-          DEFAULT: '#e5e7eb',
+          DEFAULT: '#d1d5db',
         },
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",


### PR DESCRIPTION
## Summary
- refresh color palette for a modern look
- adjust tailwind colors to match new scheme
- remove stray markdown snippet from `database-storage.ts`
- fix `userId` lookup in `users-routes.ts`

## Testing
- `npm audit --json`
- `npm run check` *(fails: TS2769 and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684102f45af8832da8c4a9f1ada9237b